### PR TITLE
Fix building release Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,12 +12,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion '28.0.3'
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : 27
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : '28.0.3'
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 27
+        minSdkVersion rootProject.hasProperty('minSdkVersion') ? rootProject.minSdkVersion : 16
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : 27
         versionCode 1
         versionName "1.0"
     }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,18 @@
+# Project-wide Gradle settings.
+
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+KAKAO_SDK_GROUP=com.kakao.sdk
+KAKAO_SDK_VERSION=1.15.1
+
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true


### PR DESCRIPTION
Hello,

I found that  there are now some issues when building release.

1. Not found KAKAO_SDK_GROUP => I added gradle.properties file
2. When trying to build with different from root project's version, it throws some errors. That I think we should use root project's version.

Please have a look.  👍 