### PR TITLE
Fix index.d.ts to resolve type error on Typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
-declare function link(options: Object): Promise<Object>;
-
-export default link;
+declare module 'react-native-kakao-links' {
+  export default class RNKakaoLink {
+    public static link(options: Object): Promise<Object>;
+  }
+}


### PR DESCRIPTION
Property 'link' does not exist on type '(options: Object) => Promise<Object>'.ts(2339)
![스크린샷 2020-05-13 오전 11 24 22](https://user-images.githubusercontent.com/52912037/81764347-536cb200-950c-11ea-87bd-f592b5bd837a.png)
